### PR TITLE
修复不设置 OnStickerOperationListener 时点击 StickerView 会闪退的 Bug

### DIFF
--- a/sticker/src/main/java/com/xiaopo/flying/sticker/StickerView.java
+++ b/sticker/src/main/java/com/xiaopo/flying/sticker/StickerView.java
@@ -342,11 +342,13 @@ public class StickerView extends FrameLayout {
     }
 
     if (handlingSticker != null) {
-      onStickerOperationListener.onStickerTouchedDown(handlingSticker);
       downMatrix.set(handlingSticker.getMatrix());
       if (bringToFrontCurrentSticker) {
         stickers.remove(handlingSticker);
         stickers.add(handlingSticker);
+      }
+      if (onStickerOperationListener != null){
+        onStickerOperationListener.onStickerTouchedDown(handlingSticker);
       }
     }
 


### PR DESCRIPTION
[issue107](https://github.com/wuapnjie/StickerView/issues/107)